### PR TITLE
Simplify SPI transfer

### DIFF
--- a/fpga/common/communications/source/spi_pwm_device.vhd
+++ b/fpga/common/communications/source/spi_pwm_device.vhd
@@ -40,7 +40,6 @@ END ENTITY spi_pwm_device;
 ARCHITECTURE rtl OF spi_pwm_device IS
 
     SIGNAL dat_rd_reg  : std_logic_vector(31 DOWNTO 0); --! Data Read Register value
-    SIGNAL dat_rd_strt : std_logic;                     --! Data Read Start flag
     SIGNAL dat_wr_reg  : std_logic_vector(31 DOWNTO 0); --! Data Write Register value 
     SIGNAL dat_wr_done : std_logic;                     --! Data Write Done flag
     
@@ -60,7 +59,6 @@ BEGIN
             spi_miso_out    => spi_miso_out,
             spi_ver_en_in   => spi_ver_en_in,
             dat_rd_reg_in   => dat_rd_reg,
-            dat_rd_strt_out => dat_rd_strt,
             dat_wr_reg_out  => dat_wr_reg,
             dat_wr_done_out => dat_wr_done
         );
@@ -72,7 +70,6 @@ BEGIN
             mod_rst_in     => mod_rst_in,
             dat_wr_done_in => dat_wr_done,
             dat_wr_reg_in  => dat_wr_reg,
-            dat_rd_strt_in => dat_rd_strt,
             dat_rd_reg_out => dat_rd_reg,
             pwm_adv_in     => pwm_adv_in,
             pwm_out        => pwm_out

--- a/fpga/common/communications/source/spi_sdm_device.vhd
+++ b/fpga/common/communications/source/spi_sdm_device.vhd
@@ -37,7 +37,6 @@ END ENTITY spi_sdm_device;
 ARCHITECTURE rtl OF spi_sdm_device IS
 
     SIGNAL dat_rd_reg  : std_logic_vector(31 DOWNTO 0); --! Data Read Register value
-    SIGNAL dat_rd_strt : std_logic;                     --! Data Read Start flag
     SIGNAL dat_wr_reg  : std_logic_vector(31 DOWNTO 0); --! Data Write Register value 
     SIGNAL dat_wr_done : std_logic;                     --! Data Write Done flag
     
@@ -57,7 +56,6 @@ BEGIN
             spi_miso_out    => spi_miso_out,
             spi_ver_en_in   => spi_ver_en_in,
             dat_rd_reg_in   => dat_rd_reg,
-            dat_rd_strt_out => dat_rd_strt,
             dat_wr_reg_out  => dat_wr_reg,
             dat_wr_done_out => dat_wr_done
         );
@@ -69,7 +67,6 @@ BEGIN
             mod_rst_in     => mod_rst_in,
             dat_wr_done_in => dat_wr_done,
             dat_wr_reg_in  => dat_wr_reg,
-            dat_rd_strt_in => dat_rd_strt,
             dat_rd_reg_out => dat_rd_reg,
             sdm_out        => sdm_out
         );

--- a/fpga/common/communications/source/spi_version_block.vhd
+++ b/fpga/common/communications/source/spi_version_block.vhd
@@ -28,7 +28,6 @@ ENTITY spi_version_block IS
         spi_miso_out    : OUT   std_logic;                     --! SPI MISO
         spi_ver_en_in   : IN    std_logic;                     --! SPI Version Enable flag
         dat_rd_reg_in   : IN    std_logic_vector(31 DOWNTO 0); --! Data Read Register value
-        dat_rd_strt_out : OUT   std_logic;                     --! Data Read Start flag
         dat_wr_reg_out  : OUT   std_logic_vector(31 DOWNTO 0); --! Data Write Register value 
         dat_wr_done_out : OUT   std_logic                      --! Data Write Done flag
     );
@@ -39,7 +38,6 @@ ARCHITECTURE rtl OF spi_version_block IS
 
     -- Internal data signals
     SIGNAL dat_rd_reg  : std_logic_vector(31 DOWNTO 0); --! Internal data read register
-    SIGNAL dat_rd_strt : std_logic;                     --! Internal data read start
     SIGNAL dat_wr_done : std_logic;                     --! Internal data write done
 
 BEGIN
@@ -54,13 +52,11 @@ BEGIN
             spi_mosi_in     => spi_mosi_in,
             spi_miso_out    => spi_miso_out,
             dat_rd_reg_in   => dat_rd_reg,
-            dat_rd_strt_out => dat_rd_strt,
             dat_wr_reg_out  => dat_wr_reg_out,
             dat_wr_done_out => dat_wr_done
         );
 
-    -- Expose read and write when not performing version operations
-    dat_rd_strt_out <= dat_rd_strt AND NOT spi_ver_en_in;
+    -- Expose write when not performing version operations
     dat_wr_done_out <= dat_wr_done AND NOT spi_ver_en_in;
 
     -- Data read is either version information, or modules read dat

--- a/fpga/common/devices/sim/pwm_device_tb.vhd
+++ b/fpga/common/devices/sim/pwm_device_tb.vhd
@@ -27,7 +27,6 @@ ARCHITECTURE tb OF pwm_device_tb IS
     SIGNAL rst         : std_logic;                     --! Reset input to pwm device
     SIGNAL dat_wr_done : std_logic;                     --! Data write done input to pwm device
     SIGNAL dat_wr_reg  : std_logic_vector(31 DOWNTO 0); --! Data write register input to pwm device
-    SIGNAL dat_rd_strt : std_logic;                     --! Data read start input to pwm device
     SIGNAL dat_rd_reg  : std_logic_vector(31 DOWNTO 0); --! Data read register output from pwm device
     SIGNAL pwm_adv     : std_logic;                     --! PWM advance input to pwm device
     SIGNAL pwm_out     : std_logic_vector(3 DOWNTO 0);  --! PWM outputs from pwm device
@@ -41,7 +40,6 @@ BEGIN
             mod_rst_in     => rst,
             dat_wr_done_in => dat_wr_done,
             dat_wr_reg_in  => dat_wr_reg,
-            dat_rd_strt_in => dat_rd_strt,
             dat_rd_reg_out => dat_rd_reg,
             pwm_adv_in     => pwm_adv,
             pwm_out        => pwm_out
@@ -71,7 +69,6 @@ BEGIN
         REPORT "Hold in Reset" SEVERITY note;
         dat_wr_reg  <= (OTHERS => '0');
         dat_wr_done <= '0';
-        dat_rd_strt <= '0';
         
         -- Reset for 8 clock periods
         rst <= '1';
@@ -84,9 +81,7 @@ BEGIN
         
         -- Read PWM device
         REPORT "Read PWM values" SEVERITY note;
-        dat_rd_strt <= '1';
         WAIT FOR c_clk_period;
-        dat_rd_strt <= '0';
         ASSERT (dat_rd_reg = B"00000000_00000000_00000000_00000000")
             REPORT "Expected pwm_device zero duty cycles after reset"
             SEVERITY error;
@@ -99,10 +94,8 @@ BEGIN
         dat_wr_done <= '0';
         
         -- Read PWM device
-        REPORT "Read PWM values" SEVERITY note;
-        dat_rd_strt <= '1';
         WAIT FOR c_clk_period;
-        dat_rd_strt <= '0';
+        REPORT "Read PWM values" SEVERITY note;
         ASSERT (dat_rd_reg = B"11111111_10101010_01010101_00000000") 
             REPORT "Expected pwm_device non zero duty cycles after configuration"
             SEVERITY error;

--- a/fpga/common/devices/source/pwm_device.vhd
+++ b/fpga/common/devices/source/pwm_device.vhd
@@ -25,7 +25,6 @@ ENTITY pwm_device IS
         mod_rst_in     : IN    std_logic;                     --! Module Reset (async)
         dat_wr_done_in : IN    std_logic;                     --! Device Write Done flag
         dat_wr_reg_in  : IN    std_logic_vector(31 DOWNTO 0); --! Device Write Register value
-        dat_rd_strt_in : IN    std_logic;                     --! Device Read Start flag
         dat_rd_reg_out : OUT   std_logic_vector(31 DOWNTO 0); --! Device Read Register value
         pwm_adv_in     : IN    std_logic;                     --! PWM Advance flag
         pwm_out        : OUT   std_logic_vector(3 DOWNTO 0)   --! PWM outputs
@@ -85,7 +84,7 @@ BEGIN
     pr_read : PROCESS (mod_clk_in) IS
     BEGIN
     
-        IF (rising_edge(mod_clk_in) AND dat_rd_strt_in = '1') THEN
+        IF (rising_edge(mod_clk_in)) THEN
             -- Populate read register with duty cycles
             dat_rd_reg_out <= std_logic_vector(to_unsigned(pwm_duty(3), 8)) &
                               std_logic_vector(to_unsigned(pwm_duty(2), 8)) &

--- a/fpga/common/devices/source/sdm_device.vhd
+++ b/fpga/common/devices/source/sdm_device.vhd
@@ -23,7 +23,6 @@ ENTITY sdm_device IS
         mod_rst_in     : IN    std_logic;                     --! Module Reset (async)
         dat_wr_done_in : IN    std_logic;                     --! Device Write Done flag
         dat_wr_reg_in  : IN    std_logic_vector(31 DOWNTO 0); --! Device Write Register value
-        dat_rd_strt_in : IN    std_logic;                     --! Device Read Start flag
         dat_rd_reg_out : OUT   std_logic_vector(31 DOWNTO 0); --! Device Read Register value
         sdm_out        : OUT   std_logic_vector(3 DOWNTO 0)   --! Modulator outputs
     );
@@ -81,7 +80,7 @@ BEGIN
     pr_read : PROCESS (mod_clk_in) IS
     BEGIN
     
-        IF (rising_edge(mod_clk_in) AND dat_rd_strt_in = '1') THEN
+        IF (rising_edge(mod_clk_in)) THEN
             -- Populate read register with levels
             dat_rd_reg_out <= std_logic_vector(sdm_level(3)) &
                               std_logic_vector(sdm_level(2)) &


### PR DESCRIPTION
Removed 'dat_rd_strt' signal to devices - they should always express their outputs.
Modified SPI format to MODE=1 (CPOL=0, CPHA=1) to simplify spi_block implementation.
Modified spi_block to used edge_detect to trigger clocking, removes need for state-machine.