### PR TITLE
Use only std_logic based ports

### DIFF
--- a/fpga/common/devices/source/pwm_device.vhd
+++ b/fpga/common/devices/source/pwm_device.vhd
@@ -35,7 +35,7 @@ END ENTITY pwm_device;
 ARCHITECTURE rtl OF pwm_device IS
 
     --! Array type of four duty-cycles
-    TYPE pwm_duty_set IS ARRAY (3 DOWNTO 0) OF integer RANGE 0 TO 255;
+    TYPE pwm_duty_set IS ARRAY (3 DOWNTO 0) OF std_logic_vector(7 DOWNTO 0);
     
     --! Duty cycles array
     SIGNAL pwm_duty : pwm_duty_set;
@@ -48,7 +48,7 @@ BEGIN
         --! Generate PWM instance
         i_pwm : ENTITY work.pwm(rtl)
             GENERIC MAP (
-                count_max => 254
+                bit_width => 8
             )
             PORT MAP (
                 mod_clk_in  => mod_clk_in,
@@ -66,16 +66,16 @@ BEGIN
         
         IF (mod_rst_in = '1') THEN
             -- Reset duty cycles
-            pwm_duty(3) <= 0;
-            pwm_duty(2) <= 0;
-            pwm_duty(1) <= 0;
-            pwm_duty(0) <= 0;
+            pwm_duty(3) <= (OTHERS => '0');
+            pwm_duty(2) <= (OTHERS => '0');
+            pwm_duty(1) <= (OTHERS => '0');
+            pwm_duty(0) <= (OTHERS => '0');
         ELSIF (rising_edge(mod_clk_in) AND dat_wr_done_in = '1') THEN
             -- Set duty cycles from write register
-            pwm_duty(3) <= to_integer(unsigned(dat_wr_reg_in(31 DOWNTO 24)));
-            pwm_duty(2) <= to_integer(unsigned(dat_wr_reg_in(23 DOWNTO 16)));
-            pwm_duty(1) <= to_integer(unsigned(dat_wr_reg_in(15 DOWNTO 8)));
-            pwm_duty(0) <= to_integer(unsigned(dat_wr_reg_in(7 DOWNTO 0)));
+            pwm_duty(3) <= dat_wr_reg_in(31 DOWNTO 24);
+            pwm_duty(2) <= dat_wr_reg_in(23 DOWNTO 16);
+            pwm_duty(1) <= dat_wr_reg_in(15 DOWNTO 8);
+            pwm_duty(0) <= dat_wr_reg_in(7 DOWNTO 0);
         END IF;
         
     END PROCESS pr_write;
@@ -86,10 +86,10 @@ BEGIN
     
         IF (rising_edge(mod_clk_in)) THEN
             -- Populate read register with duty cycles
-            dat_rd_reg_out <= std_logic_vector(to_unsigned(pwm_duty(3), 8)) &
-                              std_logic_vector(to_unsigned(pwm_duty(2), 8)) &
-                              std_logic_vector(to_unsigned(pwm_duty(1), 8)) &
-                              std_logic_vector(to_unsigned(pwm_duty(0), 8));
+            dat_rd_reg_out <= pwm_duty(3) &
+                              pwm_duty(2) &
+                              pwm_duty(1) &
+                              pwm_duty(0);
         END IF;
         
     END PROCESS pr_read;

--- a/fpga/common/devices/source/sdm_device.vhd
+++ b/fpga/common/devices/source/sdm_device.vhd
@@ -32,7 +32,7 @@ END ENTITY sdm_device;
 ARCHITECTURE rtl OF sdm_device IS
 
     --! Array type of four levels
-    TYPE sdm_level_set IS ARRAY (3 DOWNTO 0) OF unsigned(7 DOWNTO 0);
+    TYPE sdm_level_set IS ARRAY (3 DOWNTO 0) OF std_logic_vector(7 DOWNTO 0);
     
     --! Levels array
     SIGNAL sdm_level : sdm_level_set;
@@ -68,10 +68,10 @@ BEGIN
             sdm_level(0) <= (OTHERS => '0');
         ELSIF (rising_edge(mod_clk_in) AND dat_wr_done_in = '1') THEN
             -- Set levels from write register
-            sdm_level(3) <= unsigned(dat_wr_reg_in(31 DOWNTO 24));
-            sdm_level(2) <= unsigned(dat_wr_reg_in(23 DOWNTO 16));
-            sdm_level(1) <= unsigned(dat_wr_reg_in(15 DOWNTO 8));
-            sdm_level(0) <= unsigned(dat_wr_reg_in(7 DOWNTO 0));
+            sdm_level(3) <= dat_wr_reg_in(31 DOWNTO 24);
+            sdm_level(2) <= dat_wr_reg_in(23 DOWNTO 16);
+            sdm_level(1) <= dat_wr_reg_in(15 DOWNTO 8);
+            sdm_level(0) <= dat_wr_reg_in(7 DOWNTO 0);
         END IF;
         
     END PROCESS pr_write;

--- a/fpga/common/utility/sim/pwm_tb.vhd
+++ b/fpga/common/utility/sim/pwm_tb.vhd
@@ -24,11 +24,11 @@ ARCHITECTURE tb OF pwm_tb IS
 
     --! Stimulus record type
     TYPE t_stimulus IS RECORD
-        name    : string(1 TO 20);      --! Stimulus name
-        rst     : std_logic;            --! rst input to uut
-        adv     : std_logic;            --! adv input to uut
-        duty    : integer RANGE 0 TO 3; --! duty input to uut
-        percent : integer;              --! Expected percent
+        name    : string(1 TO 20);              --! Stimulus name
+        rst     : std_logic;                    --! rst input to uut
+        adv     : std_logic;                    --! adv input to uut
+        duty    : std_logic_vector(1 DOWNTO 0); --! duty input to uut
+        percent : integer;                      --! Expected percent
     END RECORD t_stimulus;
 
     --! Stimulus array type
@@ -41,52 +41,52 @@ ARCHITECTURE tb OF pwm_tb IS
             name    => "Hold in reset       ",
             rst     => '1',
             adv     => '0',
-            duty    => 3,
+            duty    => B"00",
             percent => 0
         ),
         (
             name    => "Freeze              ",
             rst     => '0',
             adv     => '0',
-            duty    => 3,
+            duty    => B"11",
             percent => 0
         ),
         (
             name    => "Running period 3    ",
             rst     => '0',
             adv     => '1',
-            duty    => 3,
+            duty    => B"11",
             percent => 100
         ),
         (
             name    => "Running period 2    ",
             rst     => '0',
             adv     => '1',
-            duty    => 2,
+            duty    => B"10",
             percent => 67
         ),
         (
             name    => "Running period 1    ",
             rst     => '0',
             adv     => '1',
-            duty    => 1,
+            duty    => B"01",
             percent => 33
         ),
         (
             name    => "Running period 0    ",
             rst     => '0',
             adv     => '1',
-            duty    => 0,
+            duty    => B"00",
             percent => 0
         )
     );
 
     -- Signals to uut
-    SIGNAL clk  : std_logic;            --! Clock input to pwm uut
-    SIGNAL rst  : std_logic;            --! Reset input to pwm uut
-    SIGNAL adv  : std_logic;            --! PWM advance input to pwm uut
-    SIGNAL duty : integer RANGE 0 TO 3; --! Duty-cycle input to pwm uut
-    SIGNAL pwm  : std_logic;            --! PWM output from pwm uut
+    SIGNAL clk  : std_logic;                    --! Clock input to pwm uut
+    SIGNAL rst  : std_logic;                    --! Reset input to pwm uut
+    SIGNAL adv  : std_logic;                    --! PWM advance input to pwm uut
+    SIGNAL duty : std_logic_vector(1 DOWNTO 0); --! Duty-cycle input to pwm uut
+    SIGNAL pwm  : std_logic;                    --! PWM output from pwm uut
     
     -- Signals to on_percent
     SIGNAL on_rst     : std_logic; --! Reset input to on_percent
@@ -97,7 +97,7 @@ BEGIN
     --! Instantiate PWM as uut
     i_uut : ENTITY work.pwm(rtl)
         GENERIC MAP (
-            count_max => 2
+            bit_width => 2
         )
         PORT MAP (
             mod_clk_in  => clk,
@@ -137,7 +137,7 @@ BEGIN
         -- Initialize entity inputs
         rst    <= '1';
         adv    <= '0';
-        duty   <= 0;
+        duty   <= B"00";
         on_rst <= '1';
         WAIT FOR c_clk_period;
 

--- a/fpga/common/utility/sim/sdm_tb.vhd
+++ b/fpga/common/utility/sim/sdm_tb.vhd
@@ -24,10 +24,10 @@ ARCHITECTURE tb OF sdm_tb IS
 
     --! Stimulus record type
     TYPE t_stimulus IS RECORD
-        name      : string(1 TO 20);      --! Stimulus name
-        rst       : std_logic;            --! rst input to uut
-        sdm_level : unsigned(1 DOWNTO 0); --! sdm_level input to uut
-        percent   : integer;              --! Expected on-percent from uut
+        name      : string(1 TO 20);              --! Stimulus name
+        rst       : std_logic;                    --! rst input to uut
+        sdm_level : std_logic_vector(1 DOWNTO 0); --! sdm_level input to uut
+        percent   : integer;                      --! Expected on-percent from uut
     END RECORD t_stimulus;
 
     --! Stimulus array type
@@ -69,10 +69,10 @@ ARCHITECTURE tb OF sdm_tb IS
     );
 
     -- Signals to uut
-    SIGNAL clk       : std_logic;            --! Clock input to sdm uut
-    SIGNAL rst       : std_logic;            --! Reset input to sdm uut
-    SIGNAL sdm_level : unsigned(1 DOWNTO 0); --! Level input to sdm uut
-    SIGNAL sdm_out   : std_logic;            --! Modulator output from sdm uut
+    SIGNAL clk       : std_logic;                    --! Clock input to sdm uut
+    SIGNAL rst       : std_logic;                    --! Reset input to sdm uut
+    SIGNAL sdm_level : std_logic_vector(1 DOWNTO 0); --! Level input to sdm uut
+    SIGNAL sdm_out   : std_logic;                    --! Modulator output from sdm uut
     
     -- Signals to on_percent
     SIGNAL on_rst     : std_logic; --! Reset input to on_percent

--- a/fpga/common/utility/source/sdm.vhd
+++ b/fpga/common/utility/source/sdm.vhd
@@ -18,13 +18,13 @@ USE ieee.numeric_std.ALL;
 --! a configurable bit-width.
 ENTITY sdm IS
     GENERIC (
-        bit_width : integer RANGE 1 TO 31 := 8 --! Bit width
+        bit_width : integer RANGE 1 TO 32 := 8 --! Bit width
     );
     PORT (
-        mod_clk_in   : IN    std_logic;                        --! Clock
-        mod_rst_in   : IN    std_logic;                        --! Reset (async)
-        sdm_level_in : IN    unsigned(bit_width - 1 DOWNTO 0); --! Modulator level
-        sdm_out      : OUT   std_logic                         --! Modulator output
+        mod_clk_in   : IN    std_logic;                                --! Clock
+        mod_rst_in   : IN    std_logic;                                --! Reset (async)
+        sdm_level_in : IN    std_logic_vector(bit_width - 1 DOWNTO 0); --! Modulator level
+        sdm_out      : OUT   std_logic                                 --! Modulator output
     );
 END ENTITY sdm;
 
@@ -45,7 +45,7 @@ BEGIN
             accumulator <= (OTHERS => '0');
         ELSIF (rising_edge(mod_clk_in)) THEN
             -- Accumulate
-            accumulator <= ('0' & accumulator(accumulator'HIGH - 1 DOWNTO 0)) + ('0' & sdm_level_in);
+            accumulator <= unsigned('0' & accumulator(accumulator'HIGH - 1 DOWNTO 0)) + unsigned('0' & sdm_level_in);
         END IF;
             
     END PROCESS pr_sdm;


### PR DESCRIPTION
Modified "rtl" synthesizable entities to only use std_logic and std_logic_vector ports.